### PR TITLE
feat: add debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker run --rm -it -v $(pwd):/data video-swear-jar \
 - [x] Allow user to define output directory
 - [x] Create logging abstraction for `info`, `warning`, `error`, `debug`, etc
 - [ ] Add unit tests
-- [ ] Add debug flag to commands
+- [x] Add debug flag to commands
 - [ ] Clean up files after process is complete
 - [ ] Allow users to pass in a custom swear-words.json file (replace or add)
 

--- a/src/clean.js
+++ b/src/clean.js
@@ -26,9 +26,15 @@ const argv = yargs.usage('clean')
       description: 'Output directory to save cleaned video',
       alias: 'o',
       default: '.'
+    },
+    debug: {
+      description: 'Run in debug mode for verbose output',
+      default: false,
+      type: 'boolean'
     }
   }).argv
 
+process.env.DEBUG = argv.debug
 const paths = utils.getFilePaths(argv.input)
 
 const run = async () => {

--- a/src/cut-video.js
+++ b/src/cut-video.js
@@ -10,34 +10,32 @@ const argv = yargs.usage('cut-video')
     timestamps: {
       description: 'Timestamps file',
       demandOption: true,
+      type: 'string',
       alias: 't'
     },
     video: {
       description: 'Video file to cut',
       demandOption: true,
+      type: 'string',
       alias: 'v'
     },
-    'cut-video': {
-      description: 'Boolean to cut video',
-      boolean: true,
-      default: true,
-      alias: 'c'
+    debug: {
+      description: 'Run in debug mode for verbose output',
+      default: false
+    }
+  }).check((argv) => {
+    if (!fs.existsSync(argv.timestamps)) {
+      throw new Error(`Error: the timestamps file "${argv.timestamps}" does not exist`)
+    }
+    if (!fs.existsSync(argv.video)) {
+      throw new Error(`Error: the video file "${argv.video}" does not exist`)
     }
   }).argv
 
+process.env.DEBUG = argv.debug
 const paths = utils.getFilePaths(argv.video)
 
 const run = async () => {
-  if (!fs.existsSync(argv.timestamps)) {
-    log.error(`The timestamps file ("${argv.timestamps}") does not exist`)
-    return
-  }
-
-  if (!fs.existsSync(argv.video)) {
-    log.error(`The video file ("${argv.video}") does not exist`)
-    return
-  }
-
   const content = fs.readFileSync(argv.timestamps).toString()
 
   const cutList = []

--- a/src/log.js
+++ b/src/log.js
@@ -17,7 +17,7 @@ const info = (message, optionalMessage = '') => {
 }
 
 const debug = (message, optionalMessage = '') => {
-  if (process.env.DEBUG) console.log(message, optionalMessage)
+  if (process.env.DEBUG === true) console.log(`[DEBUG] ${message}`, optionalMessage)
 }
 
 const notice = (message, optionalMessage = '') => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,10 @@
 const path = require('path')
 const { spawn } = require('child_process')
+const log = require('./log')
 
 const getFilePaths = (inputFile) => {
   const paths = path.parse(inputFile)
-  return {
+  const filePaths = {
     inputFile,
     transcript: `${paths.name}.json`, // automatically output by whisper in <video-file>.json
     cut: `${paths.name}-cut.txt`,
@@ -11,10 +12,14 @@ const getFilePaths = (inputFile) => {
     cutWords: `${paths.name}-cut-words.txt`,
     outputVideo: `${paths.name}-output${paths.ext}`
   }
+
+  log.debug(`file paths: ${JSON.stringify(filePaths)}`)
+  return filePaths
 }
 
 const asyncSpawn = async (command, args = []) => {
   return new Promise((resolve, reject) => {
+    log.debug(`running command: ${command} ${args.join(' ')}`)
     const process = spawn(command, args)
 
     let stdout = ''


### PR DESCRIPTION
This change adds a new `--debug` argument to the `clean` and `cut-video` commands to help debug issues when running each command.

This change also has some minor updates to the validation of arguments which can be handled by `yargs` instead of within the application. 