### PR TITLE
fix: cut-video input checks

### DIFF
--- a/src/cut-video.js
+++ b/src/cut-video.js
@@ -30,6 +30,7 @@ const argv = yargs.usage('cut-video')
     if (!fs.existsSync(argv.video)) {
       throw new Error(`Error: the video file "${argv.video}" does not exist`)
     }
+    return true
   }).argv
 
 process.env.DEBUG = argv.debug


### PR DESCRIPTION
This change fixes the `cut-video` command's input checks which must return `true` to indicate all checks have passed. See https://stackoverflow.com/a/39680558/773479 for full context of issue