### PR TITLE
fix: resolve video stutter and add timestamp output formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker run --rm -it -v $(pwd):/data video-swear-jar \
 - [ ] Add unit tests
 - [ ] Clean up files after process is complete
 - [ ] Allow users to pass in a custom swear-words.json file (replace or add)
-- [ ] Reduce container image size -- ideally less than 1GB
+- [ ] Reduce linux/amd64 container image size -- ideally less than 1GB
 
 ## Notes
 ### Alternatives

--- a/src/video.js
+++ b/src/video.js
@@ -55,15 +55,15 @@ const createCutFile = ({ transcript, paths }) => {
   let inpoint = 0
 
   for (const segment of transcript) {
-    const start = segment.start
-    const end = segment.end
+    const start = Math.floor(segment.start)
+    const end = Math.ceil(segment.end)
 
     ffmpegCuts.push(`file '${paths.cutVideo}'`)
     ffmpegCuts.push(`inpoint ${inpoint}`)
     ffmpegCuts.push(`outpoint ${start}`)
 
     inpoint = end
-    if (paths.cutWords) cutWords.push(`${start}-${inpoint}\t${segment.text.trim()}`)
+    if (paths.cutWords) cutWords.push(`${formatTime(start)} - ${formatTime(inpoint)}\t${segment.text.trim()}`)
   }
 
   // write ending inpoint to bring in remaining video
@@ -72,6 +72,18 @@ const createCutFile = ({ transcript, paths }) => {
 
   fs.writeFileSync(paths.cut, ffmpegCuts.join('\n'))
   if (paths.cutWords) fs.writeFileSync(paths.cutWords, cutWords.join('\n'))
+}
+
+const formatTime = (seconds) => {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const remainingSeconds = seconds % 60
+
+  const formattedHours = String(hours).padStart(2, '0')
+  const formattedMinutes = String(minutes).padStart(2, '0')
+  const formattedSeconds = String(remainingSeconds).padStart(2, '0')
+
+  return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`
 }
 
 module.exports = {


### PR DESCRIPTION
This change adds the following fixes & improvements

- Fixes video stutter by using whole numbers instead of decimals when cutting the video. ffmpeg did not seem to like non-whole numbers
- Improves the formatting of the time within the cut words output to use `HH:MM:SS` format